### PR TITLE
corrected spelling of the word "latest"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 WebsitePanel is a complete portal for Cloud Computing Companies and IT Providers to automate the provisioning of a full suite of Multi-Tenant services on Windows servers. The powerful, flexible open source WebsitePanel platform gives users simple point-and-click control over Windows Server applications including IIS 8.5, SQL Server 2014, MySQL 5, Exchange 2013, Sharepoint 2013, Lync 2013, Webdav, Microsoft RemoteApp and Hyper-V2 Deployments.
 
-To download the lasest Binaries or find more information visit our website at: 
+To download the latest Binaries or find more information visit our website at: 
 
 http://www.websitepanel.net/
 


### PR DESCRIPTION
Earlier simple 'latest' word was written as "lasest', which has no meaning.